### PR TITLE
[FEATURE] Categorized/faceted indexing

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -7,6 +7,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use WEBcoast\VersatileCrawler\Crawler\CrawlerInterface;
+use WEBcoast\VersatileCrawler\Exception\InvalidItemException;
 use WEBcoast\VersatileCrawler\Queue\Manager;
 use WEBcoast\VersatileCrawler\Utility\TypeUtility;
 
@@ -64,8 +65,13 @@ class CrawlerController
                     )
                 );
             }
-            $result = $result && $crawler->processQueueItem($item, $configuration);
-            $queueManager->updateState($item);
+            try {
+                $result = $result && $crawler->processQueueItem($item, $configuration);
+                $queueManager->updateState($item);
+            } catch (InvalidItemException $exception) {
+                // Remove queue items, that can not be processed, e.g. if the page is hidden
+                $queueManager->removeQueueItem($exception->getItem());
+            }
         }
 
         return $result;

--- a/Classes/Crawler/FrontendRequestCrawler.php
+++ b/Classes/Crawler/FrontendRequestCrawler.php
@@ -3,6 +3,7 @@
 namespace WEBcoast\VersatileCrawler\Crawler;
 
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -11,6 +12,8 @@ use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\IndexedSearch\Indexer;
 use WEBcoast\VersatileCrawler\Domain\Model\Item;
+use WEBcoast\VersatileCrawler\Exception\InvalidItemException;
+use WEBcoast\VersatileCrawler\Exception\PageNotAvailableForIndexingException;
 use WEBcoast\VersatileCrawler\Frontend\AbstractIndexHook;
 use WEBcoast\VersatileCrawler\Queue\Manager;
 
@@ -34,53 +37,58 @@ abstract class FrontendRequestCrawler implements CrawlerInterface, QueueInterfac
 
     public function processQueueItem(Item $item, array $configuration)
     {
-        $url = $this->buildRequestUrl($item, $configuration);
-        $hash = md5($item->getIdentifier() . time());
-        $queueManager = GeneralUtility::makeInstance(Manager::class);
-        $queueManager->prepareItemForProcessing($item->getConfiguration(), $item->getIdentifier(), $hash);
-        $curlHandle = curl_init();
-        curl_setopt_array(
-            $curlHandle,
-            [
-                CURLOPT_URL => $url,
-                CURLOPT_FOLLOWLOCATION => true,
-                CURLOPT_MAXREDIRS => 10,
-                CURLOPT_RETURNTRANSFER => true,
-                CURLINFO_HEADER_OUT => true,
-                CURLOPT_HTTPHEADER => [AbstractIndexHook::HASH_HEADER . ': ' . $hash]
-            ]
-        );
-        $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['versatile_crawler']);
-        if ((int)$extensionConfiguration['disableCertificateCheck'] === 1) {
-            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, false);
-            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, false);
-        }
-        // use this for debugging the frontend indexing part
-        if (isset($extensionConfiguration['xDebugForwardCookie']) && (int)$extensionConfiguration['xDebugForwardCookie'] === 1 && isset($_COOKIE['XDEBUG_SESSION'])) {
-            curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $_COOKIE['XDEBUG_SESSION']);
-        } elseif ($extensionConfiguration['xDebugSession'] && !empty($extensionConfiguration['xDebugSession'])) {
-            curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $extensionConfiguration['xDebugSession']);
-        }
-        $content = curl_exec($curlHandle);
-        $response = curl_getinfo($curlHandle);
-        curl_close($curlHandle);
+        try {
+            $url = $this->buildRequestUrl($item, $configuration);
+            $hash = md5($item->getIdentifier() . time());
+            $queueManager = GeneralUtility::makeInstance(Manager::class);
+            $queueManager->prepareItemForProcessing($item->getConfiguration(), $item->getIdentifier(), $hash);
+            $curlHandle = curl_init();
+            curl_setopt_array(
+                $curlHandle,
+                [
+                    CURLOPT_URL => $url,
+                    CURLOPT_FOLLOWLOCATION => true,
+                    CURLOPT_MAXREDIRS => 10,
+                    CURLOPT_RETURNTRANSFER => true,
+                    CURLINFO_HEADER_OUT => true,
+                    CURLOPT_HTTPHEADER => [AbstractIndexHook::HASH_HEADER . ': ' . $hash]
+                ]
+            );
+            $extensionConfiguration = (new ExtensionConfiguration())->get('versatile_crawler');
+            if ((int)$extensionConfiguration['disableCertificateCheck'] === 1) {
+                curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, false);
+                curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, false);
+            }
+            // use this for debugging the frontend indexing part
+            if (isset($extensionConfiguration['xDebugForwardCookie']) && (int)$extensionConfiguration['xDebugForwardCookie'] === 1 && isset($_COOKIE['XDEBUG_SESSION'])) {
+                curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $_COOKIE['XDEBUG_SESSION']);
+            } elseif ($extensionConfiguration['xDebugSession'] && !empty($extensionConfiguration['xDebugSession'])) {
+                curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $extensionConfiguration['xDebugSession']);
+            }
+            $content = curl_exec($curlHandle);
+            $response = curl_getinfo($curlHandle);
+            curl_close($curlHandle);
 
-        if ($response['http_code'] >= 200 && $response['http_code'] <= 300) {
-            $result = json_decode($content, true);
-            if (is_array($result) && $result['state'] === 'success') {
-                $item->setState(Item::STATE_SUCCESS);
+            if ($response['http_code'] >= 200 && $response['http_code'] <= 300) {
+                $result = json_decode($content, true);
+                if (is_array($result) && $result['state'] === 'success') {
+                    $item->setState(Item::STATE_SUCCESS);
+                } else {
+                    $item->setState(Item::STATE_ERROR);
+                    $item->setMessage(sprintf('An error occurred. the call to the url "%s" did not returned a valid json. This could only happen in the unlikely case of a missing "%s" header.', $response['url'], AbstractIndexHook::HASH_HEADER));
+                }
             } else {
+                $result = json_decode($content, true);
                 $item->setState(Item::STATE_ERROR);
-                $item->setMessage(sprintf('An error occurred. the call to the url "%s" did not returned a valid json. This could only happen in the unlikely case of a missing "%s" header.', $response['url'], AbstractIndexHook::HASH_HEADER));
+                if (is_array($result)) {
+                    $item->setMessage($result['message']);
+                } else {
+                    $item->setMessage(sprintf('An error occurred. The call to the url "%s" returned the status code %d', $response['url'], $response['http_code']));
+                }
             }
-        } else {
-            $result = json_decode($content, true);
-            $item->setState(Item::STATE_ERROR);
-            if (is_array($result)) {
-                $item->setMessage($result['message']);
-            } else {
-                $item->setMessage(sprintf('An error occurred. The call to the url "%s" returned the status code %d', $response['url'], $response['http_code']));
-            }
+        } catch (PageNotAvailableForIndexingException $exception) {
+            // The page may be hidden or deleted, since the last queue run, so the queue item is not valid anymore
+            throw new InvalidItemException($item);
         }
 
         return true;
@@ -89,14 +97,12 @@ abstract class FrontendRequestCrawler implements CrawlerInterface, QueueInterfac
     protected function buildRequestUrl(Item $item, array $configuration) {
         $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($item->getData()['page']);
         if ($site instanceof Site) {
-            $url = $site->getBase();
-            foreach ($site->getLanguages() as $language) {
-                if ($language->getLanguageId() === $item->getData()['sys_language_uid']) {
-                    $url = $language->getBase();
-                    break;
-                }
-            }
-            $urlParts = parse_url($url);
+            $queryParameters = [];
+            parse_str($this->buildQueryString($item, $configuration), $queryParameters);
+            unset($queryParameters['id'], $queryParameters['L'], $queryParameters['cHash']);
+            $queryParameters['_language'] = $item->getData()['sys_language_uid'];
+
+            return $site->getRouter()->generateUri($item->getData()['page'], $queryParameters);
         } else {
             $url = isset($configuration['base_url']) && !empty($configuration['base_url']) ? $configuration['base_url'] : null;
             $urlParts = parse_url($url);
@@ -109,24 +115,24 @@ abstract class FrontendRequestCrawler implements CrawlerInterface, QueueInterfac
                     $urlParts = ['host' => $domain['domainName']];
                 }
             }
-        }
-        if (!isset($urlParts['host']) || empty($urlParts['host'])) {
-            throw new \RuntimeException(sprintf('Missing host for URL to crawl. Please check you site configuration or crawler configuration.'));
-        }
-        if (!isset($urlParts['scheme']) || empty($urlParts['scheme'])) {
-            $urlParts['scheme'] = 'http';
-        }
-        if (!isset($urlParts['path']) || empty($urlParts['path'])) {
-            $urlParts['path'] = '/index.php';
-        } else {
-            if (substr($urlParts['path'], -1) !== '/') {
-                $urlParts['path'] .= '/';
+            if (!isset($urlParts['host']) || empty($urlParts['host'])) {
+                throw new \RuntimeException(sprintf('Missing host for URL to crawl. Please check you site configuration or crawler configuration.'));
             }
-            $urlParts['path'] .= 'index.php';
-        }
-        $urlParts['query'] = $this->buildQueryString($item, $configuration);
+            if (!isset($urlParts['scheme']) || empty($urlParts['scheme'])) {
+                $urlParts['scheme'] = 'http';
+            }
+            if (!isset($urlParts['path']) || empty($urlParts['path'])) {
+                $urlParts['path'] = '/index.php';
+            } else {
+                if (substr($urlParts['path'], -1) !== '/') {
+                    $urlParts['path'] .= '/';
+                }
+                $urlParts['path'] .= 'index.php';
+            }
+            $urlParts['query'] = $this->buildQueryString($item, $configuration);
 
-        return HttpUtility::buildUrl($urlParts);
+            return HttpUtility::buildUrl($urlParts);
+        }
     }
 
     /**

--- a/Classes/Exception/InvalidItemException.php
+++ b/Classes/Exception/InvalidItemException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WEBcoast\VersatileCrawler\Exception;
+
+use Throwable;
+use WEBcoast\VersatileCrawler\Domain\Model\Item;
+
+class InvalidItemException extends \Exception
+{
+    protected Item $item;
+
+    public function __construct(Item $item, $message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->item = $item;
+    }
+
+    /**
+     * @return Item
+     */
+    public function getItem(): Item
+    {
+        return $this->item;
+    }
+}

--- a/Classes/Exception/PageNotAvailableForIndexingException.php
+++ b/Classes/Exception/PageNotAvailableForIndexingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WEBcoast\VersatileCrawler\Exception;
+
+class PageNotAvailableForIndexingException extends \Exception
+{
+}

--- a/Classes/Queue/Manager.php
+++ b/Classes/Queue/Manager.php
@@ -3,7 +3,6 @@
 namespace WEBcoast\VersatileCrawler\Queue;
 
 
-use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -248,6 +247,13 @@ class Manager implements SingletonInterface
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
 
         return $connection->select(['*'], self::QUEUE_TABLE, ['hash' => $hash, 'state' => Item::STATE_IN_PROGRESS]);
+    }
+
+    public function removeQueueItem(Item $item)
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
+
+        return $connection->delete(self::QUEUE_TABLE, ['identifier' => $item->getIdentifier()]);
     }
 
     public function getFromRecord($record)

--- a/Classes/Scheduler/AbstractBaseTask.php
+++ b/Classes/Scheduler/AbstractBaseTask.php
@@ -3,15 +3,13 @@
 namespace WEBcoast\VersatileCrawler\Scheduler;
 
 
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
 abstract class AbstractBaseTask extends AbstractTask
 {
-    /**
-     * @return \TYPO3\CMS\Lang\LanguageService
-     */
-    protected function getLanguageService()
+    protected function getLanguageService(): LanguageService
     {
-        return $GLOBALS['LANG'];
+        return parent::getLanguageService() ?? LanguageService::create('default');
     }
 }

--- a/Configuration/TCA/tx_versatilecrawler_domain_model_configuration.php
+++ b/Configuration/TCA/tx_versatilecrawler_domain_model_configuration.php
@@ -1,189 +1,212 @@
 <?php
 
-return [
-    'ctrl' => [
-        'title' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration',
-        'label' => 'title',
-        'tstamp' => 'tstamp',
-        'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
-        'type' => 'type',
-        'delete' => 'deleted',
-        'enablecolumns' => [
-            'disabled' => 'disabled',
+return (function() {
+    $tca = [
+        'ctrl' => [
+            'title' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration',
+            'label' => 'title',
+            'tstamp' => 'tstamp',
+            'crdate' => 'crdate',
+            'cruser_id' => 'cruser_id',
+            'type' => 'type',
+            'delete' => 'deleted',
+            'enablecolumns' => [
+                'disabled' => 'disabled',
+            ],
+            'searchFields' => 'title',
+            'default_sortby' => 'title ASC'
         ],
-        'searchFields' => 'title',
-        'default_sortby' => 'title ASC'
-    ],
-    'columns' => [
-        'title' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.title',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'maxLength' => 100,
-                'eval' => 'trim,required'
-            ]
-        ],
-        'domain' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.domain',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'foreign_table' => 'sys_domain',
-                'items' => [
-                    ['', 0]
+        'columns' => [
+            'title' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.title',
+                'config' => [
+                    'type' => 'input',
+                    'size' => 30,
+                    'maxLength' => 100,
+                    'eval' => 'trim,required'
                 ]
-            ]
-        ],
-        'base_url' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.base_url',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'maxLength' => 200,
-                'eval' => 'trim'
-            ]
-        ],
-        'type' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'items' => [
-                    ['', ''],
-                    ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.pageTree', 'pageTree'],
-                    ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.records', 'records'],
-                    ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.files', 'files'],
-                    ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.meta', 'meta']
-                ]
-            ]
-        ],
-        'levels' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.levels',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'int',
-                'range' => [
-                    'lower' => 0,
-                    'upper' => 10
-                ],
-                'slider' => [
-                    'step' => 1,
-                    'width' => 110
-                ],
-                'default' => 0
-            ]
-        ],
-        'exclude_pages_with_configuration' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.exclude_pages_with_configuration',
-            'config' => [
-                'type' => 'check',
-                'default' => true
-            ]
-        ],
-        'languages' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.languages',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectMultipleSideBySide',
-                'special' => 'languages',
-                'minitems' => 1
-            ]
-        ],
-        'table_name' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.table_name',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'tables',
-            ]
-        ],
-        'record_storage_page' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.record_storage_page',
-            'config' => [
-                'type' => 'group',
-                'internal_type' => 'db',
-                'allowed' => 'pages',
-                'minitems' => 1,
-                'wizards' => [
-                    'suggest' => [
-                        'type' => 'suggest'
+            ],
+            'domain' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.domain',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'foreign_table' => 'sys_domain',
+                    'items' => [
+                        ['', 0]
                     ]
                 ]
+            ],
+            'base_url' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.base_url',
+                'config' => [
+                    'type' => 'input',
+                    'size' => 30,
+                    'maxLength' => 200,
+                    'eval' => 'trim'
+                ]
+            ],
+            'type' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'items' => [
+                        ['', ''],
+                        ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.pageTree', 'pageTree'],
+                        ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.records', 'records'],
+                        ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.files', 'files'],
+                        ['LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.type.meta', 'meta']
+                    ]
+                ]
+            ],
+            'indexing_configuration' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.indexing_configuration',
+                'config' => [
+                    'type' => 'group',
+                    'internal_type' => 'db',
+                    'allowed' => 'index_config',
+                    'minitems' => 0,
+                    'maxitems' => 1,
+                    'wizards' => [
+                        'suggest' => [
+                            'type' => 'suggest'
+                        ]
+                    ]
+                ]
+            ],
+            'levels' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.levels',
+                'config' => [
+                    'type' => 'input',
+                    'eval' => 'int',
+                    'range' => [
+                        'lower' => 0,
+                        'upper' => 10
+                    ],
+                    'slider' => [
+                        'step' => 1,
+                        'width' => 110
+                    ],
+                    'default' => 0
+                ]
+            ],
+            'exclude_pages_with_configuration' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.exclude_pages_with_configuration',
+                'config' => [
+                    'type' => 'check',
+                    'default' => true
+                ]
+            ],
+            'languages' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.languages',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectMultipleSideBySide',
+                    'special' => 'languages',
+                    'minitems' => 1
+                ]
+            ],
+            'table_name' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.table_name',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'special' => 'tables',
+                ]
+            ],
+            'record_storage_page' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.record_storage_page',
+                'config' => [
+                    'type' => 'group',
+                    'internal_type' => 'db',
+                    'allowed' => 'pages',
+                    'minitems' => 1,
+                    'wizards' => [
+                        'suggest' => [
+                            'type' => 'suggest'
+                        ]
+                    ]
+                ]
+            ],
+            'record_storage_page_recursive' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.record_storage_page_recursive',
+                'config' => [
+                    'type' => 'input',
+                    'eval' => 'int',
+                    'range' => [
+                        'lower' => 0,
+                        'upper' => 10
+                    ],
+                    'slider' => [
+                        'step' => 1,
+                        'width' => 110
+                    ],
+                    'default' => 1
+                ]
+            ],
+            'query_string' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.query_string',
+                'config' => [
+                    'type' => 'input',
+                    'eval' => 'trim',
+                    'default' => ''
+                ]
+            ],
+            'configurations' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.configurations',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectMultipleSideBySide',
+                    'foreign_table' => 'tx_versatilecrawler_domain_model_configuration',
+                    'MM' => 'tx_versatilecrawler_domain_model_configuration_mm',
+                    'size' => 5,
+                    'autoSizeMax' => 20
+                ]
+            ],
+            'file_storages' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.file_storages',
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectMultipleSideBySide',
+                    'foreign_table' => 'sys_file_storage',
+                    'MM' => 'tx_versatilecrawler_domain_model_configuration_file_storage_mm',
+                    'size' => 5,
+                    'autoSizeMax' => 20,
+                    'minitems' => 1
+                ]
+            ],
+            'file_extensions' => [
+                'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.file_extensions',
+                'config' => [
+                    'type' => 'input',
+                    'eval' => 'trim',
+                    'default' => ''
+                ]
+            ],
+        ],
+        'types' => [
+            '0' => [
+                'showitem' => 'title,type'
+            ],
+            'pageTree' => [
+                'showitem' => 'title,type,indexing_configuration,domain,base_url,levels,exclude_pages_with_configuration,languages'
+            ],
+            'records' => [
+                'showitem' => 'title,type,indexing_configuration,domain,base_url,table_name,record_storage_page,record_storage_page_recursive,query_string,languages'
+            ],
+            'files' => [
+                'showitem' => 'title,type,indexing_configuration,file_storages,file_extensions,languages'
+            ],
+            'meta' => [
+                'showitem' => 'title,type,indexing_configuration,configurations'
             ]
-        ],
-        'record_storage_page_recursive' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.record_storage_page_recursive',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'int',
-                'range' => [
-                    'lower' => 0,
-                    'upper' => 10
-                ],
-                'slider' => [
-                    'step' => 1,
-                    'width' => 110
-                ],
-                'default' => 1
-            ]
-        ],
-        'query_string' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.query_string',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'default' => ''
-            ]
-        ],
-        'configurations' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.configurations',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectMultipleSideBySide',
-                'foreign_table' => 'tx_versatilecrawler_domain_model_configuration',
-                'MM' => 'tx_versatilecrawler_domain_model_configuration_mm',
-                'size' => 5,
-                'autoSizeMax' => 20
-            ]
-        ],
-        'file_storages' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.file_storages',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectMultipleSideBySide',
-                'foreign_table' => 'sys_file_storage',
-                'MM' => 'tx_versatilecrawler_domain_model_configuration_file_storage_mm',
-                'size' => 5,
-                'autoSizeMax' => 20,
-                'minitems' => 1
-            ]
-        ],
-        'file_extensions' => [
-            'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:tx_versatilecrawler_domain_model_configuration.file_extensions',
-            'config' => [
-                'type' => 'input',
-                'eval' => 'trim',
-                'default' => ''
-            ]
-        ],
-    ],
-    'types' => [
-        '0' => [
-            'showitem' => 'title,type'
-        ],
-        'pageTree' => [
-            'showitem' => 'title,type,domain,base_url,levels,exclude_pages_with_configuration,languages'
-        ],
-        'records' => [
-            'showitem' => 'title,type,domain,base_url,table_name,record_storage_page,record_storage_page_recursive,query_string,languages'
-        ],
-        'files' => [
-            'showitem' => 'title,type,file_storages,file_extensions,languages'
-        ],
-        'meta' => [
-            'showitem' => 'title,type,configurations'
         ]
-    ]
-];
+    ];
+
+    if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version()) >= \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('10.0.0')) {
+        unset($tca['columns']['domain']);
+    }
+
+    return $tca;
+})();

--- a/Resources/Private/Language/locallang_backend.xlf
+++ b/Resources/Private/Language/locallang_backend.xlf
@@ -29,6 +29,9 @@
             <trans-unit id="tx_versatilecrawler_domain_model_configuration.type.files">
                 <source>Files</source>
             </trans-unit>
+            <trans-unit id="tx_versatilecrawler_domain_model_configuration.indexing_configuration">
+                <source>Indexing configuration</source>
+            </trans-unit>
             <trans-unit id="tx_versatilecrawler_domain_model_configuration.levels">
                 <source>Levels</source>
             </trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,6 +11,7 @@ CREATE TABLE tx_versatilecrawler_domain_model_configuration (
   domain int(11) NOT NULL DEFAULT '0',
   base_url varchar(200) NOT NULL DEFAULT '',
   type varchar(200) NOT NULL DEFAULT '',
+  indexing_configuration int(11) NOT NULL DEFAULT '0',
 
   # fields for page indexer
   levels tinyint(2) NOT NULL DEFAULT '0',


### PR DESCRIPTION
* categorized indexing:
  * add field `Index configuration` to crawler configuration records
  * set `freeIndexUid` to given `Index configuration` in indexing hook
* fixes for CMS 10:
  * use `Site` and its router when generating the URL for crawling
  * replace usage of `$GLOBALS['LANG']`
  * do not use `cHash` related properties in TYPO3 CMS 10
  * use `LanguageAspect` instead of `TSFE->sys_language_uid`
* avoid errors from unindexable pages:
  * check if the pages is available for indexing, right before the request
  * remove item from queue, if page is not available for indexing