### PR TITLE
[BUGFIX] `ProcessTask` loosing value of `$numberOfItemsPerRun`

### DIFF
--- a/Classes/Scheduler/ProcessTask.php
+++ b/Classes/Scheduler/ProcessTask.php
@@ -11,6 +11,7 @@ use WEBcoast\VersatileCrawler\Queue\Manager;
 
 class ProcessTask extends AbstractBaseTask implements ProgressProviderInterface
 {
+    public $numberOfItemsPerRun = 100;
 
     /**
      * This is the main method that is called when a task is executed

--- a/Classes/Scheduler/ProcessTaskAdditionalFieldProvider.php
+++ b/Classes/Scheduler/ProcessTaskAdditionalFieldProvider.php
@@ -34,7 +34,7 @@ class ProcessTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
         }
 
         $additionalFields[$fieldId] = [
-            'code' => '<input type="text" class="form-control" name="' . $fieldName . '" id="' . $fieldId . '" size="10" value="' . $taskInfo[$fieldId] . '"" />',
+            'code' => '<input type="text" class="form-control" name="' . $fieldName . '" id="' . $fieldId . '" size="10" value="' . $task->numberOfItemsPerRun . '"" />',
             'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:scheduler.processTask.numberOfItemsPerRun'
         ];
 


### PR DESCRIPTION
* correctly fill the scheduler task form when editing the task