### PR TITLE
Change PageRepository class namespace

### DIFF
--- a/Classes/Crawler/Records.php
+++ b/Classes/Crawler/Records.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\CacheHashCalculator;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\IndexedSearch\Indexer;
 use WEBcoast\VersatileCrawler\Controller\QueueController;
 use WEBcoast\VersatileCrawler\Domain\Model\Item;


### PR DESCRIPTION
For more information, please take a look here:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-88746-PageRepositoryPHPClassMovedFromFrontendToCoreExtension.html