### PR TITLE
[BUGFIX] Crawler result json in page cache

### DIFF
--- a/Classes/Frontend/AbstractIndexHook.php
+++ b/Classes/Frontend/AbstractIndexHook.php
@@ -36,6 +36,8 @@ abstract class AbstractIndexHook implements SingletonInterface
         }
 
         if ($hashHeader !== null && strcmp($hashHeader, '') !== 0) {
+            // Avoid TYPO3 putting the json result in the cache
+            $typoScriptFrontendController->no_cache = true;
             try {
                 $queueManager = GeneralUtility::makeInstance(Manager::class);
                 $itemResult = $queueManager->getItemForProcessing($hashHeader);


### PR DESCRIPTION
* set `$TSFE->no_cache = true` in crawler hook to avoid putting the result json into the page cache