### PR TITLE
[BUGFIX] TYPO3 CMS 12 compatibility

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -53,7 +53,7 @@ class CrawlerController
                 self::CONFIGURATION_TABLE,
                 ['uid' => $itemArray['configuration']]
             );
-            $configuration = $configurationResult->fetch();
+            $configuration = $configurationResult->fetchAssociative();
             $className = TypeUtility::getClassForType($configuration['type']);
             $crawler = GeneralUtility::makeInstance($className);
             if (!$crawler instanceof CrawlerInterface) {

--- a/Classes/Controller/QueueController.php
+++ b/Classes/Controller/QueueController.php
@@ -41,7 +41,7 @@ class QueueController
         $result = true;
         foreach ($configurations as $configurationUid) {
             $configurationResult = $connection->select(['*'], self::CONFIGURATION_TABLE, ['uid' => $configurationUid]);
-            $configuration = $configurationResult->fetch();
+            $configuration = $configurationResult->fetchAssociative();
             $className = TypeUtility::getClassForType($configuration['type']);
             $crawler = GeneralUtility::makeInstance($className);
             if (!$crawler instanceof QueueInterface) {

--- a/Classes/Crawler/FrontendRequestCrawler.php
+++ b/Classes/Crawler/FrontendRequestCrawler.php
@@ -59,12 +59,6 @@ abstract class FrontendRequestCrawler implements CrawlerInterface, QueueInterfac
                 curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, false);
                 curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, false);
             }
-            // use this for debugging the frontend indexing part
-            if (isset($extensionConfiguration['xDebugForwardCookie']) && (int)$extensionConfiguration['xDebugForwardCookie'] === 1 && isset($_COOKIE['XDEBUG_SESSION'])) {
-                curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $_COOKIE['XDEBUG_SESSION']);
-            } elseif ($extensionConfiguration['xDebugSession'] && !empty($extensionConfiguration['xDebugSession'])) {
-                curl_setopt($curlHandle, CURLOPT_COOKIE, 'XDEBUG_SESSION=' . $extensionConfiguration['xDebugSession']);
-            }
             $content = curl_exec($curlHandle);
             $response = curl_getinfo($curlHandle);
             curl_close($curlHandle);

--- a/Classes/Crawler/Meta.php
+++ b/Classes/Crawler/Meta.php
@@ -11,14 +11,7 @@ use WEBcoast\VersatileCrawler\Utility\TypeUtility;
 
 class Meta implements QueueInterface
 {
-
-    /**
-     * @param array $configuration
-     * @param array $rootConfiguration
-     *
-     * @return boolean
-     */
-    public function fillQueue(array $configuration, array $rootConfiguration = null)
+    public function fillQueue(array $configuration, ?array $rootConfiguration = null): bool
     {
         if ($rootConfiguration === null) {
             $rootConfiguration = $configuration;
@@ -36,8 +29,8 @@ class Meta implements QueueInterface
             $query->expr()->eq('m.uid_local', $configuration['uid'])
         );
         $result = true;
-        if ($statement = $query->execute()) {
-            foreach ($statement as $subConfiguration) {
+        if ($statement = $query->executeQuery()) {
+            foreach ($statement->fetchAllAssociative() as $subConfiguration) {
                 $className = TypeUtility::getClassForType($subConfiguration['type']);
                 $crawler = GeneralUtility::makeInstance($className);
                 if (!$crawler instanceof QueueInterface) {

--- a/Classes/Crawler/PageTree.php
+++ b/Classes/Crawler/PageTree.php
@@ -80,7 +80,7 @@ class PageTree extends FrontendRequestCrawler
                             'uid!=' . $configuration['uid'],
                             'uid!=' . $rootConfiguration['uid']
                         );
-                    if ($query->execute()->fetchColumn(0) > 0) {
+                    if ($query->executeQuery()->fetchOne() > 0) {
                         continue;
                     }
                 }

--- a/Classes/Crawler/PageTree.php
+++ b/Classes/Crawler/PageTree.php
@@ -3,7 +3,6 @@
 namespace WEBcoast\VersatileCrawler\Crawler;
 
 
-use Doctrine\DBAL\DBALException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
@@ -39,15 +38,7 @@ class PageTree extends FrontendRequestCrawler
         }
     }
 
-    /**
-     * @param array      $configuration
-     * @param array|null $rootConfiguration
-     *
-     * @throws DBALException
-     *
-     * @return boolean
-     */
-    public function fillQueue(array $configuration, array $rootConfiguration = null)
+    public function fillQueue(array $configuration, ?array $rootConfiguration = null): bool
     {
         if ($rootConfiguration === null) {
             $rootConfiguration = $configuration;
@@ -132,7 +123,7 @@ class PageTree extends FrontendRequestCrawler
         return $result;
     }
 
-    protected function getPagesRecursively($page, &$pages, $level)
+    protected function getPagesRecursively($page, &$pages, $level): void
     {
         $subPages = $this->pageRepository->getMenu($page['uid']);
         foreach ($subPages as $subPage) {
@@ -144,14 +135,9 @@ class PageTree extends FrontendRequestCrawler
     }
 
     /**
-     * @param \WEBcoast\VersatileCrawler\Domain\Model\Item $item
-     * @param array                                        $configuration
-     *
      * @throws PageNotAvailableForIndexingException
-     *
-     * @return string
      */
-    protected function buildQueryString(Item $item, array $configuration)
+    protected function buildQueryString(Item $item, array $configuration): string
     {
         $data = $item->getData();
         $page = $this->pageRepository->getPage($data['page']);
@@ -162,13 +148,7 @@ class PageTree extends FrontendRequestCrawler
         return 'id=' . $data['page'] . '&L=' . $data['sys_language_uid'];
     }
 
-    /**
-     * @param \WEBcoast\VersatileCrawler\Domain\Model\Item                $item
-     * @param \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $typoScriptFrontendController
-     *
-     * @return boolean
-     */
-    public function isIndexingAllowed(Item $item, TypoScriptFrontendController $typoScriptFrontendController)
+    public function isIndexingAllowed(Item $item, TypoScriptFrontendController $typoScriptFrontendController): bool
     {
         $data = $item->getData();
         return ($data['page'] === (int)$typoScriptFrontendController->id && $data['sys_language_uid'] === GeneralUtility::makeInstance(Context::class)->getAspect('language')->getId());

--- a/Classes/Domain/Model/Item.php
+++ b/Classes/Domain/Model/Item.php
@@ -31,7 +31,7 @@ class Item extends AbstractEntity
     /**
      * @var array
      */
-    protected $data;
+    protected array $data;
 
     /**
      * Item constructor.
@@ -42,7 +42,7 @@ class Item extends AbstractEntity
      * @param string         $message
      * @param array          $data
      */
-    public function __construct($configuration, $identifier, $state = self::STATE_PENDING, $message = '', $data = [])
+    public function __construct($configuration, $identifier, $state = self::STATE_PENDING, $message = '', array $data = [])
     {
         $this->configuration = $configuration;
         $this->identifier = $identifier;
@@ -67,51 +67,36 @@ class Item extends AbstractEntity
         return $this->identifier;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getState()
+    public function getState(): int
     {
         return $this->state;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMessage()
+    public function setState(int $state): self
+    {
+        $this->state = $state;
+        return $this;
+    }
+
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getData()
+    public function setMessage(string $message): self
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    public function getData(): array
     {
         return $this->data;
     }
 
-    /**
-     * @param mixed $state
-     */
-    public function setState($state)
-    {
-        $this->state = $state;
-    }
-
-    /**
-     * @param mixed $message
-     */
-    public function setMessage($message)
-    {
-        $this->message = $message;
-    }
-
-    /**
-     * @param mixed $data
-     */
-    public function setData($data)
+    public function setData(array $data): self
     {
         $this->data = $data;
+        return $this;
     }
 }

--- a/Classes/Middleware/IndexingMiddleware.php
+++ b/Classes/Middleware/IndexingMiddleware.php
@@ -8,13 +8,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\PageTitle\PageTitleProviderManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\IndexedSearch\Indexer;
 use WEBcoast\VersatileCrawler\Controller\CrawlerController;
@@ -27,6 +25,20 @@ use WEBcoast\VersatileCrawler\Utility\TypeUtility;
 class IndexingMiddleware implements MiddlewareInterface
 {
     public const HASH_HEADER = 'X-Versatile-Crawler-Hash';
+
+    protected PageTitleProviderManager $pageTitleProviderManager;
+    
+    protected Indexer $indexer;
+
+    /**
+     * @param PageTitleProviderManager $pageTitleProviderManager
+     * @param Indexer                  $indexer
+     */
+    public function __construct(PageTitleProviderManager $pageTitleProviderManager, Indexer $indexer)
+    {
+        $this->pageTitleProviderManager = $pageTitleProviderManager;
+        $this->indexer = $indexer;
+    }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -47,8 +59,7 @@ class IndexingMiddleware implements MiddlewareInterface
             }
 
             $queueManager = GeneralUtility::makeInstance(Manager::class);
-            $itemResult = $queueManager->getItemForProcessing($hash);
-            $itemRecord = $itemResult->fetch();
+            $itemRecord = $queueManager->getItemForProcessing($hash);
             if (!is_array($itemRecord)) {
                 return new JsonResponse(
                     [
@@ -110,7 +121,7 @@ class IndexingMiddleware implements MiddlewareInterface
     public function processIndexing(Item $item, TypoScriptFrontendController &$typoScriptFrontendController, FrontendRequestCrawler $crawler, ServerRequestInterface $request)
     {
         /** @var LanguageAspect $languageAspect */
-        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $languageAspect = $typoScriptFrontendController->getContext()->getAspect('language');
         if ($languageAspect->getId() === $languageAspect->getContentId()) {
             $data = $item->getData();
             $rootConfiguration = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(CrawlerController::CONFIGURATION_TABLE)->select(
@@ -121,47 +132,35 @@ class IndexingMiddleware implements MiddlewareInterface
                 [],
                 1
             )->fetchAssociative();
-            $indexer = GeneralUtility::makeInstance(Indexer::class);
-            $indexer->conf = [];
-            $indexer->conf['id'] = $typoScriptFrontendController->id;
-            $indexer->conf['type'] = $typoScriptFrontendController->type;
-            $indexer->conf['sys_language_uid'] = $languageAspect->getId();
-            $indexer->conf['MP'] = $typoScriptFrontendController->MP;
-            $indexer->conf['gr_list'] = implode(',', GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'groupIds', [0, -1]));;
-            if (VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version()) < VersionNumberUtility::convertVersionNumberToInteger('10.0.0')) {
-                // These two properties do not exist anymore in TYPO3 CMS 10
-                $indexer->conf['cHash'] = $typoScriptFrontendController->cHash;
-                $indexer->conf['cHash_array'] = $typoScriptFrontendController->cHash_array;
-            }
-            $indexer->conf['staticPageArguments'] = [];
-            $pageArguments = $request->getAttribute('routing');
-            if ($pageArguments instanceof PageArguments) {
-                $indexer->conf['staticPageArguments'] = $pageArguments->getStaticArguments();
-            }
-            $indexer->conf['crdate'] = $typoScriptFrontendController->page['crdate'];
-            $indexer->conf['page_cache_reg1'] = $typoScriptFrontendController->page_cache_reg1;
-            $indexer->conf['rootline_uids'] = [];
+            $pageArguments = $typoScriptFrontendController->getPageArguments();
+            $this->indexer->conf = [];
+            $this->indexer->conf['id'] = $typoScriptFrontendController->id;
+            $this->indexer->conf['type'] = $pageArguments->getPageType();
+            $this->indexer->conf['sys_language_uid'] = $languageAspect->getId();
+            $this->indexer->conf['MP'] = $typoScriptFrontendController->MP;
+            $this->indexer->conf['gr_list'] = implode(',', $typoScriptFrontendController->getContext()->getPropertyFromAspect('frontend.user', 'groupIds', [0, -1]));
+            $this->indexer->conf['staticPageArguments'] = $pageArguments->getStaticArguments();
+            $this->indexer->conf['crdate'] = $typoScriptFrontendController->page['crdate'];
+            $this->indexer->conf['page_cache_reg1'] = $typoScriptFrontendController->page_cache_reg1;
+            $this->indexer->conf['rootline_uids'] = [];
             foreach ($typoScriptFrontendController->config['rootLine'] as $rlkey => $rldat) {
-                $indexer->conf['rootline_uids'][$rlkey] = $rldat['uid'];
+                $this->indexer->conf['rootline_uids'][$rlkey] = $rldat['uid'];
             }
-            $indexer->conf['content'] = $typoScriptFrontendController->content;
-            $indexer->conf['indexedDocTitle'] = $typoScriptFrontendController->convOutputCharset(
-                !empty($typoScriptFrontendController->altPageTitle) ? $typoScriptFrontendController->altPageTitle : $typoScriptFrontendController->indexedDocTitle
-            );
-            $indexer->conf['metaCharset'] = $typoScriptFrontendController->metaCharset;
-            $indexer->conf['mtime'] = $typoScriptFrontendController->register['SYS_LASTCHANGED'] ?? $typoScriptFrontendController->page['SYS_LASTCHANGED'];
-            $indexer->conf['index_externals'] = $typoScriptFrontendController->config['config']['index_externals'];
-            $indexer->conf['index_descrLgd'] = $typoScriptFrontendController->config['config']['index_descrLgd'];
-            $indexer->conf['index_metatags'] = isset($typoScriptFrontendController->config['config']['index_metatags']) ?? true;
-            $indexer->conf['recordUid'] = $crawler->getRecordUid($item);
-            $indexer->conf['freeIndexUid'] = $rootConfiguration['indexing_configuration'];
-            $indexer->conf['freeIndexSetId'] = 0;
+            $this->indexer->conf['content'] = $typoScriptFrontendController->content;
+            $this->indexer->conf['indexedDocTitle'] = $this->pageTitleProviderManager->getTitle();
+            $this->indexer->conf['mtime'] = $typoScriptFrontendController->register['SYS_LASTCHANGED'] ?? $typoScriptFrontendController->page['SYS_LASTCHANGED'];
+            $this->indexer->conf['index_externals'] = $typoScriptFrontendController->config['config']['index_externals'] ?? true;
+            $this->indexer->conf['index_descrLgd'] = $typoScriptFrontendController->config['config']['index_descrLgd'] ?? 0;
+            $this->indexer->conf['index_metatags'] = $typoScriptFrontendController->config['config']['index_metatags'] ?? true;
+            $this->indexer->conf['recordUid'] = $crawler->getRecordUid($item);
+            $this->indexer->conf['freeIndexUid'] = $rootConfiguration['indexing_configuration'] ?? 0;
+            $this->indexer->conf['freeIndexSetId'] = 0;
 
             // use this to override `crdate` and `mtime` and other information (used for record indexing)
-            $crawler->enrichIndexData($item, $typoScriptFrontendController, $indexer);
+            $crawler->enrichIndexData($item, $typoScriptFrontendController, $this->indexer);
 
-            $indexer->init();
-            $indexer->indexTypo3PageContent();
+            $this->indexer->init();
+            $this->indexer->indexTypo3PageContent();
         }
     }
 }

--- a/Classes/Queue/Manager.php
+++ b/Classes/Queue/Manager.php
@@ -19,8 +19,6 @@ class Manager implements SingletonInterface
      * @param \WEBcoast\VersatileCrawler\Domain\Model\Item $item
      *
      * @return bool
-     *
-     * @throws \Doctrine\DBAL\DBALException
      */
     public function addOrUpdateItem(Item $item)
     {
@@ -62,7 +60,6 @@ class Manager implements SingletonInterface
      *
      * @return bool
      *
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \RuntimeException
      */
     public function updateState($item)
@@ -169,12 +166,7 @@ class Manager implements SingletonInterface
         );
     }
 
-    /**
-     * @return int
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    public function countAllItems()
+    public function countAllItems(): int
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
 
@@ -185,12 +177,7 @@ class Manager implements SingletonInterface
         );
     }
 
-    /**
-     * @return int
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    public function countFinishedItems()
+    public function countFinishedItems(): int
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
         $query = $connection->createQueryBuilder()->count('*')->from(self::QUEUE_TABLE);
@@ -204,7 +191,7 @@ class Manager implements SingletonInterface
         return $query->executeQuery()->fetchOne();
     }
 
-    public function countSuccessfulItems()
+    public function countSuccessfulItems(): int
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
         $query = $connection->createQueryBuilder()->count('*')->from(self::QUEUE_TABLE);
@@ -215,7 +202,7 @@ class Manager implements SingletonInterface
         return $query->executeQuery()->fetchOne();
     }
 
-    public function countFailedItems()
+    public function countFailedItems(): int
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::QUEUE_TABLE);
         $query = $connection->createQueryBuilder()->count('*')->from(self::QUEUE_TABLE);
@@ -256,7 +243,7 @@ class Manager implements SingletonInterface
         return $connection->delete(self::QUEUE_TABLE, ['identifier' => $item->getIdentifier()]);
     }
 
-    public function getFromRecord($record)
+    public function getFromRecord($record): Item
     {
         return new Item(
             $record['configuration'],

--- a/Classes/Queue/Manager.php
+++ b/Classes/Queue/Manager.php
@@ -47,7 +47,7 @@ class Manager implements SingletonInterface
                     'tstamp' => time(),
                     'state' => Item::STATE_PENDING,
                     'message' => '',
-                    'data' => json_encode($item->getData())
+                    'data' => $item->getData()
                 ]
             );
 

--- a/Classes/Scheduler/AbstractAdditionalFieldProvider.php
+++ b/Classes/Scheduler/AbstractAdditionalFieldProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WEBcoast\VersatileCrawler\Scheduler;
+
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+abstract class AbstractAdditionalFieldProvider extends \TYPO3\CMS\Scheduler\AbstractAdditionalFieldProvider
+{
+    protected function getLanguageService(): ?LanguageService
+    {
+        return $GLOBALS['LANG'] ?? LanguageService::create('default');
+    }
+}

--- a/Classes/Scheduler/AbstractBaseTask.php
+++ b/Classes/Scheduler/AbstractBaseTask.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
 abstract class AbstractBaseTask extends AbstractTask
 {
-    protected function getLanguageService(): LanguageService
+    protected function getLanguageService(): ?LanguageService
     {
         return parent::getLanguageService() ?? LanguageService::create('default');
     }

--- a/Classes/Scheduler/ProcessTask.php
+++ b/Classes/Scheduler/ProcessTask.php
@@ -3,7 +3,6 @@
 namespace WEBcoast\VersatileCrawler\Scheduler;
 
 
-use Doctrine\DBAL\DBALException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\ProgressProviderInterface;
 use WEBcoast\VersatileCrawler\Controller\CrawlerController;
@@ -22,7 +21,7 @@ class ProcessTask extends AbstractBaseTask implements ProgressProviderInterface
      *
      * @return bool Returns TRUE on successful execution, FALSE on error
      */
-    public function execute()
+    public function execute(): bool
     {
         $crawlerController = GeneralUtility::makeInstance(CrawlerController::class);
 
@@ -37,18 +36,14 @@ class ProcessTask extends AbstractBaseTask implements ProgressProviderInterface
     public function getProgress()
     {
         $queueManager = GeneralUtility::makeInstance(Manager::class);
-        try {
-            $totalItems = $queueManager->countAllItems();
-            $finishedItems = $queueManager->countFinishedItems();
+        $totalItems = $queueManager->countAllItems();
+        $finishedItems = $queueManager->countFinishedItems();
 
-            if ($totalItems === 0) {
-                return 0;
-            }
-
-            return $finishedItems / $totalItems * 100;
-        } catch (DBALException $e) {
+        if ($totalItems === 0) {
             return 0;
         }
+
+        return $finishedItems / $totalItems * 100;
     }
 
     public function getAdditionalInformation()

--- a/Classes/Scheduler/ProcessTaskAdditionalFieldProvider.php
+++ b/Classes/Scheduler/ProcessTaskAdditionalFieldProvider.php
@@ -4,16 +4,17 @@ namespace WEBcoast\VersatileCrawler\Scheduler;
 
 
 use TYPO3\CMS\Core\Messaging\FlashMessage;
-use TYPO3\CMS\Scheduler\AdditionalFieldProviderInterface;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
-class ProcessTaskAdditionalFieldProvider implements AdditionalFieldProviderInterface
+class ProcessTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {
     /**
      * Gets additional fields to render in the form to add/edit a task
      *
      * @param array                                                     $taskInfo        Values of the fields from the
      *                                                                                   add/edit task form
-     * @param \TYPO3\CMS\Scheduler\Task\AbstractTask                    $task            The task object being edited.
+     * @param AbstractTask                    $task            The task object being edited.
      *                                                                                   Null when adding a task!
      * @param \TYPO3\CMS\Scheduler\Controller\SchedulerModuleController $schedulerModule Reference to the scheduler
      *                                                                                   backend module
@@ -29,12 +30,12 @@ class ProcessTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
         $fieldId = 'versatileCrawler_processTask_numberOfItemsPerRun';
         $fieldName = 'tx_scheduler[' . $fieldId . ']';
 
-        if ($schedulerModule->CMD === 'edit' && $task instanceof processTask && !isset($taskInfo[$fieldId])) {
+        if ($schedulerModule->getCurrentAction() == Action::EDIT && $task instanceof ProcessTask && !isset($taskInfo[$fieldId])) {
             $taskInfo[$fieldId] = $task->numberOfItemsPerRun;
         }
 
         $additionalFields[$fieldId] = [
-            'code' => '<input type="text" class="form-control" name="' . $fieldName . '" id="' . $fieldId . '" size="10" value="' . $task->numberOfItemsPerRun . '"" />',
+            'code' => '<input type="text" class="form-control" name="' . $fieldName . '" id="' . $fieldId . '" size="10" value="' . ($task ? $task->numberOfItemsPerRun ?? 100 : 100) . '"" />',
             'label' => 'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:scheduler.processTask.numberOfItemsPerRun'
         ];
 
@@ -59,7 +60,7 @@ class ProcessTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
                 $submittedData['versatileCrawler_processTask_numberOfItemsPerRun'],
                 ''
             ) !== 0 && (int)$submittedData['versatileCrawler_processTask_numberOfItemsPerRun'] < 1) {
-            $schedulerModule->addMessage(
+            $this->addMessage(
                 $this->getLanguageService()->sL(
                     'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:scheduler.processTask.error.numberOfItemsPerRun'
                 ),
@@ -76,18 +77,10 @@ class ProcessTaskAdditionalFieldProvider implements AdditionalFieldProviderInter
      *
      * @param array                                  $submittedData An array containing the data submitted by the
      *                                                              add/edit task form
-     * @param \TYPO3\CMS\Scheduler\Task\AbstractTask $task          Reference to the scheduler backend module
+     * @param AbstractTask $task          Reference to the scheduler backend module
      */
-    public function saveAdditionalFields(array $submittedData, \TYPO3\CMS\Scheduler\Task\AbstractTask $task)
+    public function saveAdditionalFields(array $submittedData, AbstractTask $task)
     {
         $task->numberOfItemsPerRun = $submittedData['versatileCrawler_processTask_numberOfItemsPerRun'];
-    }
-
-    /**
-     * @return \TYPO3\CMS\Lang\LanguageService
-     */
-    protected final function getLanguageService()
-    {
-        return $GLOBALS['LANG'];
     }
 }

--- a/Classes/Scheduler/QueueTask.php
+++ b/Classes/Scheduler/QueueTask.php
@@ -23,14 +23,14 @@ class QueueTask extends AbstractBaseTask
      *
      * @return bool Returns TRUE on successful execution, FALSE on error
      */
-    public function execute()
+    public function execute(): bool
     {
         $queueController = GeneralUtility::makeInstance(QueueController::class);
 
         return $queueController->fillQueue($this->configurations);
     }
 
-    public function getAdditionalInformation()
+    public function getAdditionalInformation(): string
     {
         $configurationNames = [];
 
@@ -43,7 +43,7 @@ class QueueTask extends AbstractBaseTask
                 QueueController::CONFIGURATION_TABLE,
                 ['uid' => $configurationUid]
             );
-            $configuration = $configurationResult->fetch();
+            $configuration = $configurationResult->fetchAssociative();
             if (is_array($configuration) && isset($configuration['title'])) {
                 $configurationNames[] = $configuration['title'];
             }

--- a/Classes/Scheduler/QueueTaskAdditionalFieldProvider.php
+++ b/Classes/Scheduler/QueueTaskAdditionalFieldProvider.php
@@ -2,13 +2,13 @@
 
 namespace WEBcoast\VersatileCrawler\Scheduler;
 
-
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Scheduler\AdditionalFieldProviderInterface;
+use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
+use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
 
-class QueueTaskAdditionalFieldProvider implements AdditionalFieldProviderInterface
+class QueueTaskAdditionalFieldProvider extends AbstractAdditionalFieldProvider
 {
     const CONFIGURATION_TABLE = 'tx_versatilecrawler_domain_model_configuration';
 
@@ -25,7 +25,7 @@ class QueueTaskAdditionalFieldProvider implements AdditionalFieldProviderInterfa
      * @return array A two dimensional array, array('Identifier' => array('fieldId' => array('code' => '', 'label' =>
      *               '', 'cshKey' => '', 'cshLabel' => ''))
      */
-    public function getAdditionalFields(array &$taskInfo, $task, \TYPO3\CMS\Scheduler\Controller\SchedulerModuleController $schedulerModule)
+    public function getAdditionalFields(array &$taskInfo, $task, SchedulerModuleController $schedulerModule)
     {
         $additionalFields = [];
 
@@ -33,7 +33,7 @@ class QueueTaskAdditionalFieldProvider implements AdditionalFieldProviderInterfa
         $fieldId = 'versatileCrawler_queueTask_configuration';
         $fieldName = 'tx_scheduler[' . $fieldId . '][]';
 
-        if ($schedulerModule->CMD === 'edit' && $task instanceof QueueTask && !isset($taskInfo[$fieldId])) {
+        if ($schedulerModule->getCurrentAction() == Action::EDIT && $task instanceof QueueTask && !isset($taskInfo[$fieldId])) {
             $taskInfo[$fieldId] = $task->configurations;
         }
         $fieldOptions = $this->getConfigurationOptions($taskInfo);
@@ -61,7 +61,7 @@ class QueueTaskAdditionalFieldProvider implements AdditionalFieldProviderInterfa
     {
         $isValid = true;
         if (empty($submittedData['versatileCrawler_queueTask_configuration'])) {
-            $schedulerModule->addMessage(
+            $this->addMessage(
                 $this->getLanguageService()->sL(
                     'LLL:EXT:versatile_crawler/Resources/Private/Language/locallang_backend.xlf:scheduler.queueTask.error.emptyConfiguration'
                 ),
@@ -95,20 +95,12 @@ class QueueTaskAdditionalFieldProvider implements AdditionalFieldProviderInterfa
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(
             self::CONFIGURATION_TABLE
         );
-        $configurations = $connection->select(['uid', 'title'], self::CONFIGURATION_TABLE, [], [], ['title' => 'ASC']);
+        $configurations = $connection->select(['uid', 'title'], self::CONFIGURATION_TABLE, [], [], ['title' => 'ASC'])->fetchAllAssociative();
         $options = [];
         foreach ($configurations as $configuration) {
-            $options[] = '<option value="' . $configuration['uid'] . '" ' . (is_array($taskInfo['versatileCrawler_queueTask_configuration']) && in_array($configuration['uid'], $taskInfo['versatileCrawler_queueTask_configuration']) ? ' selected="selected"' : '') . ' >' . $configuration['title'] . '</option>';
+            $options[] = '<option value="' . $configuration['uid'] . '" ' . (is_array($taskInfo['versatileCrawler_queueTask_configuration'] ?? null) && in_array($configuration['uid'], $taskInfo['versatileCrawler_queueTask_configuration'] ?? []) ? ' selected="selected"' : '') . ' >' . $configuration['title'] . '</option>';
         }
 
         return implode('', $options);
-    }
-
-    /**
-     * @return \TYPO3\CMS\Lang\LanguageService
-     */
-    protected final function getLanguageService()
-    {
-        return $GLOBALS['LANG'];
     }
 }

--- a/Classes/Tca/TableSelectItems.php
+++ b/Classes/Tca/TableSelectItems.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace WEBcoast\VersatileCrawler\Tca;
+
+
+class TableSelectItems
+{
+    public function addTableItems(&$parameters): void
+    {
+        $items = &$parameters['items'];
+
+        foreach ($GLOBALS['TCA'] as $table => $configuration) {
+            if (in_array($table, ['pages', 'tt_content', 'sys_category']) || str_starts_with($table, 'tx_')) {
+                $items[] = [
+                    'label' => $configuration['ctrl']['title'],
+                    'value' => $table
+                ];
+            }
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    WEBcoast\VersatileCrawler\:
+        resource: '../Classes/*'

--- a/Configuration/TCA/tx_versatilecrawler_domain_model_configuration.php
+++ b/Configuration/TCA/tx_versatilecrawler_domain_model_configuration.php
@@ -101,7 +101,7 @@ return (function() {
                 'config' => [
                     'type' => 'select',
                     'renderType' => 'selectSingle',
-                    'special' => 'tables',
+                    'itemsProcFunc' => \WEBcoast\VersatileCrawler\Tca\TableSelectItems::class . '->addTableItems',
                 ]
             ],
             'record_storage_page' => [

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
 		}
 	},
 	"require": {
-		"typo3/cms-core": "^v10.4 || ^v11.5"
+		"typo3/cms-core": "^v10.4 || ^v11.5 || ^v12.4"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
 		}
 	},
 	"require": {
-		"typo3/cms-core": "^v10.4 || ^v11.5 || ^v12.4"
+		"typo3/cms-core": "^v12.4"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		}
 	},
 	"require": {
+		"php": "^8.1",
 		"typo3/cms-core": "^v12.4"
 	}
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,9 +3,3 @@ disableCertificateCheck = 0
 
 # cat=crawling; type=string; label=Page doktypes to crawl
 pagesDoktypes = 1
-
-# cat=debugging; type=boolean; label=Forward XDebug session cookie
-xDebugForwardCookie = 0
-
-# cat=debugging; type=string; label=XDebug session
-xDebugSession =

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'plugin',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-11.5.99',
+            'typo3' => '10.4.0-12.4.99',
         ],
         'conflicts' => [
             'crawler' => ''

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'plugin',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-12.4.99',
+            'typo3' => '12.4.0-12.4.99',
         ],
         'conflicts' => [
             'crawler' => ''

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,14 +1,16 @@
 <?php
 
-if (TYPO3_MODE === 'BE') {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages(
-        'tx_versatilecrawler_domain_model_configuration'
-    );
-
-    $iconRegistry = TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Imaging\IconRegistry::class);
-    $iconRegistry->registerIcon(
-        'tcarecords-tx_versatilecrawler_domain_model_configuration-default',
-        TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-        ['source' => 'EXT:versatile_crawler/Resources/Public/Icons/tx_versatilecrawler_domain_model_configuration.svg']
-    );
+if (!defined('TYPO3')) {
+    die('Access denied.');
 }
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages(
+    'tx_versatilecrawler_domain_model_configuration'
+);
+
+$iconRegistry = TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Imaging\IconRegistry::class);
+$iconRegistry->registerIcon(
+    'tcarecords-tx_versatilecrawler_domain_model_configuration-default',
+    TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+    ['source' => 'EXT:versatile_crawler/Resources/Public/Icons/tx_versatilecrawler_domain_model_configuration.svg']
+);


### PR DESCRIPTION
* update dependencies to TYPO3 CMS 12
* use new database API
* adjust indexing to match TYPO3 CMS 12 default indexing
* adjust additional fields providers to work with TYPO3 CMS 12
* remove support for older TYPO3 versions
* remove extra debug settings
* correctly encode/decode queue item data to/form JSON
* replace deprecated fetch API
* use site finder to find root page ID as `sys_domain` not longer exists
* remove and cleanup some doc headers and add return types
* check more carefully, if a message is available
* log crawling errors using TYPO3 logging capabilities
* use `itemsProcFunc` to display items for table name for record crawler configuration